### PR TITLE
Remove Ubuntu 12.04 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
         "14.04"
       ]
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "praekeltfoundation-xylem",
-  "version": "0.0.3",
+  "version": "0.0.3-dev",
   "author": "Colin Alston",
   "summary": "Basic module to manage Xylem",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
The seed repo doesn't actually have packages for Precise, but the declared support for it means we run all our tests again unnecessarily.
