### PR TITLE
Put docker-xylem socket in our own place

### DIFF
--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -44,7 +44,6 @@ class xylem::docker (
     ensure  => present,
     content => 'unix:///run/docker-xylem.sock',
     mode    => '0644',
-    require => File['/etc/docker/plugins'],
   }
 
   package { 'docker-xylem':

--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -34,10 +34,17 @@ class xylem::docker (
   # This directory doesn't really belong to us, but we need it to exist and
   # docker apparently doesn't create it. Therefore, we manage it only if
   # nothing else already does.
-  unless defined(File['/run/docker/plugins']) {
-    file { '/run/docker/plugins':
+  unless defined(File['/etc/docker/plugins']) {
+    file { '/etc/docker/plugins':
       ensure => 'directory',
     }
+  }
+
+  file { '/etc/docker/plugins/xylem.spec':
+    ensure  => present,
+    content => 'unix:///run/docker-xylem.sock',
+    mode    => '0644',
+    require => File['/etc/docker/plugins'],
   }
 
   package { 'docker-xylem':
@@ -52,7 +59,7 @@ class xylem::docker (
   ~>
   service { 'docker-xylem':
     ensure  => running,
-    require => File['/run/docker/plugins'],
+    require => File['/etc/docker/plugins/xylem.spec'],
   }
 
   if defined(Class['xylem::repo']) {

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -27,20 +27,25 @@ describe 'xylem::docker' do
                 'host' => 'gfs.local',
                 'port' => 7701,
                 'mount_path' => '/var/lib/docker/volumes',
-                'socket' => '/run/docker/plugins/xylem.sock',
+                'socket' => '/run/docker-xylem.sock',
               }))
             .that_requires('Package[docker-xylem]')
         end
 
         it do
-          is_expected.to contain_file('/run/docker/plugins')
+          is_expected.to contain_file('/etc/docker/plugins/xylem.spec')
+            .with_content('unix:///run/docker-xylem.sock')
+        end
+
+        it do
+          is_expected.to contain_file('/etc/docker/plugins')
             .with_ensure('directory')
         end
 
         it do
           is_expected.to contain_service('docker-xylem')
             .with_ensure('running')
-            .that_requires('File[/run/docker/plugins]')
+            .that_requires('File[/etc/docker/plugins/xylem.spec]')
             .that_subscribes_to('File[/etc/docker/xylem-plugin.yml]')
         end
       end

--- a/templates/xylem-plugin.yml.erb
+++ b/templates/xylem-plugin.yml.erb
@@ -1,4 +1,4 @@
 host: <%= @backend %>
 port: 7701
 mount_path: /var/lib/docker/volumes
-socket: /run/docker/plugins/xylem.sock
+socket: /run/docker-xylem.sock


### PR DESCRIPTION
`/run/docker/plugins` doesn't always exist, which is a problem if we want to put our socket there.
